### PR TITLE
Fix broken button

### DIFF
--- a/src/jvmMain/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/html/components/Buttons.kt
+++ b/src/jvmMain/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/html/components/Buttons.kt
@@ -13,7 +13,7 @@ fun FlowContent.idButton(text: String) = run {
 
 fun FlowContent.linkButton(text: String, link: String) = run {
     a(classes = "waves-effect waves-light btn-large orange") {
-        +text
         href = link
+        +text
     }
 }


### PR DESCRIPTION
I'm not sure why but setting the text before the href causes the server to crash when creating the button.

This fixes it though.