### PR TITLE
Check out all history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
           distribution: corretto
       - name: 🛒 Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: 🔑 Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
We're currently using the default fetch depth of 1, which won't work for calculating the version from previous commits.