### PR TITLE
Add deletion delay

### DIFF
--- a/src/jvmMain/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/rooms/RoomRepositoryConfig.kt
+++ b/src/jvmMain/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/rooms/RoomRepositoryConfig.kt
@@ -1,0 +1,11 @@
+package uk.co.developmentanddinosaurs.apps.poker.application.rooms
+
+import java.util.Properties
+
+class RoomRepositoryConfig {
+    private val properties by lazy {
+        Properties().apply { load(RoomRepositoryConfig::class.java.getResourceAsStream("/application.properties")) }
+    }
+
+    val deletionDelayMillis: Long = properties.getProperty("room-repository-deletion-delay-millis").toLong()
+}

--- a/src/jvmMain/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/routing/RoutingModule.kt
+++ b/src/jvmMain/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/routing/RoutingModule.kt
@@ -10,9 +10,10 @@ import io.ktor.server.websocket.webSocket
 import uk.co.developmentanddinosaurs.apps.poker.application.extensions.respondCss
 import uk.co.developmentanddinosaurs.apps.poker.application.html.css.style
 import uk.co.developmentanddinosaurs.apps.poker.application.rooms.RoomRepository
+import uk.co.developmentanddinosaurs.apps.poker.application.rooms.RoomRepositoryConfig
 import uk.co.developmentanddinosaurs.apps.poker.application.services.NameGenerator
 
-private val controller = PokerAppController(RoomRepository(NameGenerator()))
+private val controller = PokerAppController(RoomRepository(NameGenerator(), RoomRepositoryConfig()))
 
 /**
  * Apply routing logic to the web server.

--- a/src/jvmMain/resources/application.properties
+++ b/src/jvmMain/resources/application.properties
@@ -1,0 +1,1 @@
+room-repository-deletion-delay-millis=600000

--- a/src/jvmTest/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/rooms/RoomRepositoryConfigTest.kt
+++ b/src/jvmTest/kotlin/uk/co/developmentanddinosaurs/apps/poker/application/rooms/RoomRepositoryConfigTest.kt
@@ -1,0 +1,13 @@
+package uk.co.developmentanddinosaurs.apps.poker.application.rooms
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class RoomRepositoryConfigTest : StringSpec({
+
+    "Can read deletion delay from properties" {
+        val config = RoomRepositoryConfig()
+
+        config.deletionDelayMillis shouldBe 600000
+    }
+})


### PR DESCRIPTION
This adds a 10-minute delay before a room is deleted once it is marked for deletion.

This will allow people to quickly "nip back in" to a room without having to create another.

I was considering having rooms auto-create on a GET request, but something about idempotency made me reconsider.

Fixes #37